### PR TITLE
Support fontawesome4

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The process runs on a list of `ProviderInstance`, or `ProviderConstructor` insta
   - License: [Font Awesome Free License](https://fontawesome.com/license/free)
   - Required npm package: `@fortawesome/fontawesome-free`
   - styles: `solid`, `regular`, `brands` allowed by the Fontawesome Free license
+- `Fa4Provider`
+  - Source: [FontAwesome 4](https://www.npmjs.com/package/font-awesome) by @fontawesome
+  - License: Same with ``FaFreeProvider``, need download manually from [Font Awesome Free License](https://fontawesome.com/license/free).
+  - Required npm package: `font-awesome`
+  - styles: no styles.
 - `MdiProvider`
   - Source: [Material Design Icons](https://materialdesignicons.com/) by Austin Andrews
   - License: [MIT license](https://github.com/Templarian/MaterialDesign/blob/master/LICENSE)
@@ -76,7 +81,7 @@ The process runs on a list of `ProviderInstance`, or `ProviderConstructor` insta
   - License: [Apache License version 2.0](https://github.com/marella/material-icons/blob/main/LICENSE)
   - Required npm packages: `material-icons` and `@material-design-icons/svg`
 
-Note: For provider with styles properties, the program will extract all available style of that icon.
+Note: For provider with styles properties, the program will extract all available styles of that icon.
 
 The syntax to create a `ProviderInstance` is:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subset-iconfont",
-  "version": "0.2.1",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "subset-iconfont",
-      "version": "0.2.1",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0",
@@ -33,6 +33,7 @@
         "copyfiles": "^2.4.1",
         "eslint": "^8.17.0",
         "eslint-plugin-prettier": "^4.0.0",
+        "font-awesome": "^4.7.0",
         "material-icons": "^1.11.2",
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
@@ -2456,6 +2457,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.3"
+      }
     },
     "node_modules/fontverter": {
       "version": "2.0.0",
@@ -7836,6 +7846,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "dev": true
     },
     "fontverter": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "copyfiles": "^2.4.1",
     "eslint": "^8.17.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "font-awesome": "^4.7.0",
     "material-icons": "^1.11.2",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",

--- a/src/demo-standalone.js
+++ b/src/demo-standalone.js
@@ -5,6 +5,7 @@ const {
   MdiProvider,
   BiProvider,
   MiProvider,
+  Fa4Provider,
 } = require('./index');
 
 const outputDir = './output-standalone';
@@ -48,3 +49,12 @@ const mi = new MiProvider(
 );
 
 mi.makeFonts(outputDir);
+
+const fa4 = new Fa4Provider(
+  [
+    '__all__',
+  ],
+  { formats: ['ttf', 'woff2']}
+);
+
+fa4.makeFonts(outputDir);

--- a/src/providers/constants.ts
+++ b/src/providers/constants.ts
@@ -35,10 +35,15 @@ export const MI_STYLES: Style[] = [
   'two-tone',
 ];
 
+export const FONT_AWESOME4_PACKAGE_NAME = 'font-awesome';
+export const FONT_AWESOME4_DEFAULT_CSS_PREFIX = 'fa';
+export const FONT_AWESOME4_DEFAULT_FONT_NAME = 'FontAwesome 4';
+export const FONT_AWESOME4_DEFAULT_FONT_FILE_NAME = 'font-awesome-4';
+
 export const FONT_AWESOME_FREE_PACKAGE_NAME = '@fortawesome/fontawesome-free';
 export const FONT_AWESOME_FREE_DEFAULT_CSS_PREFIX = 'fa';
-export const FONT_AWESOME_DEFAULT_FONT_NAME = 'FontAwesome Free';
-export const FONT_AWESOME_DEFAULT_FONT_FILE_NAME = 'fontawesome-free';
+export const FONT_AWESOME_FREE_DEFAULT_FONT_NAME = 'FontAwesome Free';
+export const FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME = 'fontawesome-free';
 
 export const BOOTSTRAP_ICON_PACKAGE_NAME = 'bootstrap-icons';
 export const BOOTSTRAP_ICON_CSS_PREFIX = 'bi';

--- a/src/providers/fontawesome.ts
+++ b/src/providers/fontawesome.ts
@@ -4,8 +4,8 @@ const yaml = require('js-yaml');
 
 import { ProviderConstructor } from './base';
 import {
-  FONT_AWESOME_DEFAULT_FONT_FILE_NAME,
-  FONT_AWESOME_DEFAULT_FONT_NAME,
+  FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME,
+  FONT_AWESOME_FREE_DEFAULT_FONT_NAME,
   FONT_AWESOME_FREE_DEFAULT_CSS_PREFIX,
   FONT_AWESOME_FREE_PACKAGE_NAME,
 } from './constants';
@@ -22,8 +22,8 @@ class FaFreeProvider extends ProviderConstructor implements ProviderInterface {
   packageName = FONT_AWESOME_FREE_PACKAGE_NAME;
   minVersion = '5.0';
   cssPrefix = FONT_AWESOME_FREE_DEFAULT_CSS_PREFIX;
-  fontName = FONT_AWESOME_DEFAULT_FONT_NAME;
-  fontFileName = FONT_AWESOME_DEFAULT_FONT_FILE_NAME;
+  fontName = FONT_AWESOME_FREE_DEFAULT_FONT_NAME;
+  fontFileName = FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME;
 
   style2FontFileMap = {
     brands: 'webfonts/fa-brands-400.ttf',

--- a/src/providers/fontawesome4.ts
+++ b/src/providers/fontawesome4.ts
@@ -1,0 +1,77 @@
+import { ProviderInterface } from '../types/Provider';
+
+import { ProviderConstructor } from './base';
+import {
+  FONT_AWESOME4_DEFAULT_FONT_FILE_NAME,
+  FONT_AWESOME4_DEFAULT_FONT_NAME,
+  FONT_AWESOME4_DEFAULT_CSS_PREFIX,
+  FONT_AWESOME4_PACKAGE_NAME,
+  DEFAULT_STYLE,
+} from './constants';
+import { resolve } from 'path';
+import { readFileSync} from 'fs';
+import { MetaData } from '../types/Metadata';
+import { SubsetItem } from '../types/SubsetItem';
+import { ProviderOptions } from '../types/ProviderOptions';
+
+/**
+ * ProviderConstructor for Font Awesome 4.
+ */
+class Fa4Provider extends ProviderConstructor implements ProviderInterface {
+  packageName = FONT_AWESOME4_PACKAGE_NAME;
+  cssPrefix = FONT_AWESOME4_DEFAULT_CSS_PREFIX;
+  fontName = FONT_AWESOME4_DEFAULT_FONT_NAME;
+  fontFileName = FONT_AWESOME4_DEFAULT_FONT_FILE_NAME;
+  hasMultipleStyles = false;
+
+  style2FontFileMap = {
+    [DEFAULT_STYLE]: 'fonts/fontawesome-webfont.ttf'
+  };
+
+  constructor(subset: SubsetItem[], options?: ProviderOptions) {
+    super(subset, options);
+  }
+
+  moreValidation() {
+    super.moreValidation();
+    this.validateSubPath('fonts');
+    this.validateSubPath('scss/_variables.scss');
+  }
+
+  getAllMetaData() {
+    const scssFilePath = resolve(this.baseDir, 'scss/_variables.scss');
+
+    const ret: any = {};
+
+    // We were not able a valid meta data file in this package,
+    // so we have to read the scss file to get it.
+    const pattern = /\$fa-var-([0-9a-z-]+): "\\([a-f0-9]+)"/g,
+      scssFileContent = readFileSync(scssFilePath).toString();
+    let match;
+    do {
+      match = pattern.exec(scssFileContent);
+      if (match) {
+        ret[match[1]] = { unicode: match[2] };
+      }
+    } while (match);
+
+    return ret;
+  }
+
+  normalizeIconMeta(iconName: SubsetItem): MetaData {
+    return {
+      unicode: this.allMetaData[iconName].unicode,
+      svgDataObjects: [
+        {
+          style: DEFAULT_STYLE,
+
+          // todo: shall we completely remove svgDtaObjects?
+          svgData: "",
+        },
+      ],
+      styles: [DEFAULT_STYLE]
+    };
+  }
+}
+
+export { Fa4Provider };

--- a/src/providers/material_icons.ts
+++ b/src/providers/material_icons.ts
@@ -54,7 +54,7 @@ class MiProvider extends ProviderConstructor implements ProviderInterface {
 
     // We were not able a valid meta data file in this package,
     // so we have to read the css file to get it.
-    const pattern = /mi-([a-z-]+)::before{content:"\\([a-e0-9]+)"/g,
+    const pattern = /mi-([0-9a-z-]+)::before{content:"\\([a-z0-9]+)"/g,
       cssFileContent = readFileSync(cssFile).toString();
     let match;
     do {

--- a/src/providers/providers.ts
+++ b/src/providers/providers.ts
@@ -2,5 +2,6 @@ import { MdiProvider } from './material_design_icons';
 import { FaFreeProvider } from './fontawesome';
 import { BiProvider } from './bootstrap_icons';
 import { MiProvider } from './material_icons';
+import { Fa4Provider } from './fontawesome4';
 
-export { MdiProvider, FaFreeProvider, BiProvider, MiProvider };
+export { MdiProvider, FaFreeProvider, BiProvider, MiProvider, Fa4Provider };

--- a/tests/combine.mocha.ts
+++ b/tests/combine.mocha.ts
@@ -14,7 +14,7 @@ import {
 import {
   MDI_DEFAULT_FONT_FILE_NAME,
   DEFAULT_OUTPUT_FORMATS,
-  FONT_AWESOME_DEFAULT_FONT_FILE_NAME,
+  FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME,
   DEFAULT_COMBINE_FILE_NAME,
   COMBINED_CSS_NAME,
   LICENSE_FILE_NAME,
@@ -235,7 +235,7 @@ describe('General tests', () => {
           {
             names: {
               exist: ['fa-regular-400', 'fa-solid-900'],
-              nonExist: [FONT_AWESOME_DEFAULT_FONT_FILE_NAME],
+              nonExist: [FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME],
             },
             extensions: { exist: DEFAULT_OUTPUT_FORMATS },
           },

--- a/tests/providers.mocha.ts
+++ b/tests/providers.mocha.ts
@@ -7,15 +7,16 @@ const fs = require('fs');
 const winston = require('winston');
 const assert = require('assert');
 
-import { MdiProvider, FaFreeProvider, BiProvider, MiProvider } from '../src';
+import { MdiProvider, FaFreeProvider, BiProvider, MiProvider, Fa4Provider } from '../src';
 import {
   MDI_DEFAULT_FONT_FILE_NAME,
   DEFAULT_OUTPUT_FORMATS,
-  FONT_AWESOME_DEFAULT_FONT_FILE_NAME,
+  FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME,
   DEFAULT_COMBINE_FILE_NAME,
   COMBINED_CSS_NAME,
   BOOTSTRAP_ICONS_FONT_FILE_NAME,
   MI_DEFAULT_FONT_FILE_NAME,
+  FONT_AWESOME4_DEFAULT_FONT_FILE_NAME
 } from '../src/providers/constants';
 
 import {
@@ -28,7 +29,7 @@ import {
 } from './helpers';
 
 import { ConfigError } from '../src/utils/errors';
-import { MakeFontResult } from '../dist/process/types/MakeFontResult';
+import { MakeFontResult } from '../src/process/types/MakeFontResult';
 
 const sinon = require('sinon');
 
@@ -88,7 +89,7 @@ describe('Providers should be able to work alone', () => {
       },
       done,
       {
-        providerSubPath: FONT_AWESOME_DEFAULT_FONT_FILE_NAME,
+        providerSubPath: FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME,
         providerCssFiles: [
           {
             names: {
@@ -96,7 +97,7 @@ describe('Providers should be able to work alone', () => {
                 COMBINED_CSS_NAME,
                 'fa-regular',
                 'fa-solid',
-                FONT_AWESOME_DEFAULT_FONT_FILE_NAME,
+                FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME,
               ],
               nonExist: [DEFAULT_COMBINE_FILE_NAME],
             },
@@ -107,7 +108,7 @@ describe('Providers should be able to work alone', () => {
           {
             names: {
               exist: ['fa-regular-400', 'fa-solid-900'],
-              nonExist: [FONT_AWESOME_DEFAULT_FONT_FILE_NAME],
+              nonExist: [FONT_AWESOME_FREE_DEFAULT_FONT_FILE_NAME],
             },
             extensions: { exist: DEFAULT_OUTPUT_FORMATS },
           },
@@ -197,6 +198,45 @@ describe('Providers should be able to work alone', () => {
 
         metaDataExist: true,
         licenseFilesExist: true,
+        webPageFileExist: true,
+      }
+    );
+  });
+
+  it('fa4 (Font Awesome 4) should be able to work alone', (done) => {
+    generateProviderSubsetFont(
+      Fa4Provider,
+      {
+        subset: ['non-exist-icon', 'check'], // cloud-haze-1 doesn't exist as a file
+      },
+      done,
+      {
+        providerSubPath: FONT_AWESOME4_DEFAULT_FONT_FILE_NAME,
+        providerCssFiles: [
+          {
+            names: {
+              exist: [
+                COMBINED_CSS_NAME,
+                FONT_AWESOME4_DEFAULT_FONT_FILE_NAME,
+              ],
+            },
+            extensions: { exist: DEFAULT_CSS_OUTPUT_EXTENSIONS },
+          },
+        ],
+
+        providerFontFiles: [
+          {
+            names: {
+              exist: [
+                FONT_AWESOME4_DEFAULT_FONT_FILE_NAME,
+              ],
+            },
+            extensions: { exist: DEFAULT_OUTPUT_FORMATS },
+          },
+        ],
+
+        metaDataExist: true,
+        licenseFilesExist: false,
         webPageFileExist: true,
       }
     );


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Add support for FontAwesome 4 (old version which has no `-solid`, `-regular` styles);

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [ ] Snapshot test
  - [x] Manual test
  - [ ] Another test...

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [ ] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [ ] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [ ] My changes generate no new warnings or errors;
