### PR TITLE
Warn user when using "_" instead of "-" in iconNames

### DIFF
--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -179,10 +179,20 @@ export abstract class ProviderConstructor implements ProviderInterface {
   }
 
   private validateIconMeta(iconName: SubsetItem): MetaData {
-    if (typeof this.allMetaData[iconName] === 'undefined')
+    if (typeof this.allMetaData[iconName] === 'undefined') {
+      if (iconName.includes('_')) {
+        const alterIconName = iconName.replace(/_/g, '-');
+        if ('undefined' !== typeof this.allMetaData[alterIconName]) {
+          throw new WarningError(
+            `"${iconName}" does not exists in metadata available, ` +
+            `do you mean "${alterIconName}" instead?`
+          );
+        }
+      }
       throw new WarningError(
         `"${iconName}" does not exists in metadata available.`
       );
+    }
 
     const metaData: MetaData = this.normalizeIconMeta(iconName);
 

--- a/tests/combine.mocha.ts
+++ b/tests/combine.mocha.ts
@@ -158,6 +158,31 @@ describe('General tests', () => {
     );
   });
 
+  it('should not work for iconName with "_" instead of "-" as separator', (done) => {
+    // The first will log: do you mean "arrow-left" instead?
+    // the second will log: "icon_does_not_exists" does not exists in metadata available
+    const mdi = new MdiProvider(['arrow_left', 'icon_does_not_exists']);
+
+    generateCombinedSubsetFont(
+      {
+        subset: [mdi],
+      },
+      done,
+
+      // this should generate nothing, we simply check if the css is generated.
+      {
+        cssFileNames: [
+          {
+            names: {
+              nonExist: [COMBINED_CSS_NAME, DEFAULT_COMBINE_FILE_NAME],
+            },
+            extensions: { exist: [] },
+          },
+        ],
+      }
+    );
+  });
+
   it('should not work for mdi when icons not exist were input multiple times', (done) => {
     const mdi = new MdiProvider([
       'icon-does-not-exists',


### PR DESCRIPTION
## Summary

### Proposed changes

This PR brings the following changes:

- Warn user when using `_` instead of `-` in iconNames

### Related issue

#229 #298 

---

### Testing

- [x] I have added or updated tests that prove my fix is effective or that my feature works (if applicable)
  - [x] Unit test
  - [ ] Snapshot test
  - [x] Manual test

---

## Checklist

- [x] I have added corresponding labels to this PR (like bug, enhancement...);
- [x] My commits follow the [Conventional Commits 1.0 Guidelines](https://www.conventionalcommits.org/en/v1.0.0/);
- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my own code;
- [x] I have mapped technical debts found on my changes;
- [x] I have made changes to the documentation (if applicable);
- [ ] My changes generate no new warnings or errors;
